### PR TITLE
Updated README instructions for adding dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,12 @@ The pop-parser library is available as a Maven package through Github Packages a
     <url>https://maven.pkg.github.com/jamesross03/pop-parser</url>
   </repository>
 </repositories>
+
+<dependencies>
+  <dependency>
+    <groupId>com.github.jamesross03</groupId> 
+    <artifactId>pop-parser</artifactId>
+    <version>1.0.0-alpha</version>
+  </dependency>
+</dependencies>
 ```


### PR DESCRIPTION
Updated instructions in README for adding the pop-parser library as a dependency, as they were previously incomplete and only added the repository not the dependency.