### PR TITLE
Implements type-safety for record-types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.jamesross03</groupId>
     <artifactId>pop-parser</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-alpha</version>
+    <version>1.1.0-alpha</version>
     <name>pop-parser</name>
 
     <build>

--- a/src/main/java/com/github/jamesross03/pop_parser/Constants.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/Constants.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 
 import com.github.jamesross03.pop_parser.utils.RecordFactory;
 import com.github.jamesross03.pop_parser.utils.RecordFormat;
+import com.github.jamesross03.pop_parser.utils.Record;
 import com.github.jamesross03.pop_parser.utils.factories.*;
 import com.github.jamesross03.pop_parser.utils.records.*;
 
@@ -15,7 +16,7 @@ public class Constants {
     /**
      * Map of pairs of Record classes and their corresponding factories.
      */
-    public static final Map<Class<?>, Function<RecordFormat, RecordFactory<?>>> FACTORY_MAP = Map.of(
+    public static final Map<Class<? extends Record>, Function<RecordFormat, RecordFactory<? extends Record>>> FACTORY_MAP = Map.of(
         BirthRecord.class, BirthRecordFactory::new
     );
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
@@ -2,6 +2,7 @@ package com.github.jamesross03.pop_parser;
 
 import com.github.jamesross03.pop_parser.utils.RecordFactory;
 import com.github.jamesross03.pop_parser.utils.RecordFormat;
+import com.github.jamesross03.pop_parser.utils.Record;
 import com.opencsv.CSVReaderHeaderAware;
 import com.opencsv.exceptions.CsvValidationException;
 
@@ -15,7 +16,7 @@ import java.util.Map;
  * Parser for CSV files containing Records, where <T> is the Record class
  * (e.g BirthRecord).
  */
-public class RecordParser<T> {
+public class RecordParser<T extends Record> {
     /**
      * Record Factory implementation used to create records from line in CSV.
      */

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/Record.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/Record.java
@@ -1,0 +1,11 @@
+package com.github.jamesross03.pop_parser.utils;
+
+
+/**
+ * Abstract class representing a Record type. Currently doesn't contain any 
+ * variables or functions but provides type-safety for generic factory classes
+ * which take a type <T>
+ */
+public abstract class Record {
+    // See above.
+}

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFactory.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFactory.java
@@ -6,7 +6,7 @@ import java.util.Map;
  * Abstract factory class for making record <T> objects from a line of CSV 
  * input. 
  */
-public abstract class RecordFactory<T> {
+public abstract class RecordFactory<T extends Record> {
     protected final RecordFormat format;
 
     /**

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/records/BirthRecord.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/records/BirthRecord.java
@@ -1,9 +1,11 @@
 package com.github.jamesross03.pop_parser.utils.records;
 
+import com.github.jamesross03.pop_parser.utils.Record;
+
 /**
  * Object representing a Birth Record.
  */
-public class BirthRecord {
+public class BirthRecord extends Record {
     private final String forename;
     private final String surname;
 

--- a/src/test/java/com/github/jamesross03/pop_parser/RecordParserTest.java
+++ b/src/test/java/com/github/jamesross03/pop_parser/RecordParserTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import com.github.jamesross03.pop_parser.utils.Record;
 import com.github.jamesross03.pop_parser.utils.RecordFormat;
 import com.github.jamesross03.pop_parser.utils.formats.*;
 import com.github.jamesross03.pop_parser.utils.records.*;
@@ -19,7 +20,7 @@ public class RecordParserTest {
      * @param type Record type <T> being parsed
      * @param format RecordFormat corresponding to file contents
      */
-    private <T> void testParsing(String path, Class type, RecordFormat format) {
+    private <T extends Record> void testParsing(String path, Class type, RecordFormat format) {
         try {
             URL filepath = getClass().getClassLoader().getResource(path);
             assertNotNull(filepath, "Failed to load test-data at `" + path +"`");


### PR DESCRIPTION
Implements an abstract generic Record parent-class, containing no functionality, to type-safe generic classes which take a type <T> by changing this to <T extends Record>. Closes #13 