### PR TITLE
Javadocs and pages deployment

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,0 +1,32 @@
+name: Deploy Javadoc to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  javadoc:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'corretto'
+        java-version: '21'
+        cache: 'maven'
+
+    - name: Build Javadoc
+      run: mvn -B javadoc:javadoc
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./target/site/apidocs
+        publish_branch: gh-pages
+        force_orphan: true

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,4 +1,4 @@
-name: Deploy Javadoc to GitHub Pages
+name: Deploy Javadoc to /docs on main
 
 on:
   push:
@@ -20,13 +20,21 @@ jobs:
         java-version: '21'
         cache: 'maven'
 
-    - name: Build Javadoc
+    - name: Generate Javadoc
       run: mvn -B javadoc:javadoc
 
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./target/site/apidocs
-        publish_branch: gh-pages
-        force_orphan: true
+    - name: Copy Javadoc to /docs
+      run: |
+        rm -rf docs
+        mkdir -p docs
+        cp -r target/site/apidocs/* docs/
+
+    - name: Commit and push docs
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add docs
+        git commit -m "Update Javadoc [skip ci]" || echo "No changes to commit"
+        git push
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main/java/com/github/jamesross03/pop_parser/Constants.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/Constants.java
@@ -10,11 +10,12 @@ import com.github.jamesross03.pop_parser.utils.factories.*;
 import com.github.jamesross03.pop_parser.utils.records.*;
 
 /**
- * Defines constants used in the library
+ * Defines constants used in the pop-parser library.
  */
 public class Constants {
     /**
-     * Map of pairs of Record classes and their corresponding factories.
+     * Map of &lt;{@code Record} subclass, {@link RecordFactory} subclass
+     * instance&gt; pairs used to get corresponding factory.
      */
     public static final Map<Class<? extends Record>, Function<RecordFormat, RecordFactory<? extends Record>>> FACTORY_MAP = Map.of(
         BirthRecord.class, BirthRecordFactory::new

--- a/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
@@ -13,24 +13,28 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Parser for CSV files containing Records, where <T> is the Record class
- * (e.g BirthRecord).
+ * Parser for CSV input files containing records, where type {@code T} is a
+ * subclass of the {@code Record} abstract class representing the type of
+ * records (e.g birth).
+ * 
+ * @param <T> subclass of {@code Record} to be parsed
  */
 public class RecordParser<T extends Record> {
     /**
-     * Record Factory implementation used to create records from line in CSV.
+     * {@link RecordFactory} instance used to create {@code T}  objects from input.
      */
     private final RecordFactory<T> rf;
 
     /**
-     * Creates a new instance of the RecordParser class for <T> records.
+     * Initialises a new instance of {@code RecordParser} for parsing records of
+     * type {@code T} from input in a given format.
      * 
-     * @param type Record type <T> being parsed
-     * @param format RecordFormat corresponding to file contents
+     * @param type class of {@code Record} subclass to parse
+     * @param format format of input
      */
     @SuppressWarnings("unchecked")
     public RecordParser(Class<T> type, RecordFormat format) {
-        // Gets generic recordFactory corresponding to type <T>
+        // Gets RecordFactory instance corresponding to <T>
         var constructor = Constants.FACTORY_MAP.get(type);
 
         if (constructor == null) {
@@ -42,12 +46,12 @@ public class RecordParser<T extends Record> {
     }
 
     /**
-     * Reads all lines from an input file into <T> record objects.
+     * Parses all lines from an input file into objects of {@code Record} subclass {@code T}
      * 
-     * @param filepath 
-     * @return List of <T> record objects
-     * @throws IOException
-     * @throws CsvValidationException
+     * @param filepath filepath of input CSV
+     * @return list containing the parsed {@code T} objects
+     * @throws IOException if errors occur during file-reading
+     * @throws CsvValidationException if CSV is invalid or incorrectly formatted
      */
     public List<T> parse (String filepath) throws IOException, CsvValidationException {
         List<T> list = new ArrayList<T>();

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/Record.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/Record.java
@@ -2,9 +2,8 @@ package com.github.jamesross03.pop_parser.utils;
 
 
 /**
- * Abstract class representing a Record type. Currently doesn't contain any 
- * variables or functions but provides type-safety for generic factory classes
- * which take a type <T>
+ * Abstract class representing a record. Doesn't define any variables or
+ * functions but provides type-safety for typed classes.
  */
 public abstract class Record {
     // See above.

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFactory.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFactory.java
@@ -3,25 +3,34 @@ package com.github.jamesross03.pop_parser.utils;
 import java.util.Map;
 
 /**
- * Abstract factory class for making record <T> objects from a line of CSV 
- * input. 
+ * Abstract factory class for making objects of Record subclass {@code T} from a
+ * line of CSV input. 
+ * 
+ * @param <T> subclass of Record abstract class
  */
 public abstract class RecordFactory<T extends Record> {
+    /**
+     * Structure of records being input.
+     */
     protected final RecordFormat format;
 
     /**
-     * Creates a new instance of a RecordFactory subclass for a given
-     * RecordFormat 
+     * Instialises a new instance of a RecordFactory subclass for use with a
+     * given RecordFormat 
      * 
-     * @param format format to use
+     * @param format record format to use
      */
     public RecordFactory(RecordFormat format) {
         this.format = format;
     }
     
     /**
-     * @param entry Map of <header, value> pairs
-     * @return generated <T>
+     * Takes a map of attribute names and their corresponding values,
+     * representing a line read in from a record file, and uses them to create a
+     * new Record object of subclass T.
+     * 
+     * @param entry Map of &lt;key, value&gt; pairs from a line of input
+     * @return generated instance of Record subclass
      */
     public abstract T makeRecord(Map<String, String> entry);
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFormat.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFormat.java
@@ -3,10 +3,23 @@ package com.github.jamesross03.pop_parser.utils;
 import java.util.Map;
 
 /**
- * Abstract class representing a RecordFormat
+ * Abstract class representing a format of record input.
  */
 public abstract class RecordFormat {
-    // Birth records
+    // ----- Birth records -----
+    /**
+     * Gets forename from a birth record
+     * 
+     * @param row Map of &lt;key, value&gt; pairs from a line of input
+     * @return forename
+     */
     public abstract String getForenameBirth(Map<String, String> row);
+
+    /**
+     * Gets surname from a birth record
+     * 
+     * @param row Map of &lt;key, value&gt; pairs from a line of input
+     * @return surname
+     */
     public abstract String getSurnameBirth(Map<String, String> row);
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/factories/BirthRecordFactory.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/factories/BirthRecordFactory.java
@@ -7,8 +7,8 @@ import com.github.jamesross03.pop_parser.utils.RecordFormat;
 import com.github.jamesross03.pop_parser.utils.records.BirthRecord;
 
 /**
- * Implementation of IRecordFactory interface for creating BirthRecords from
- * lines of CSV input.
+ * {@link RecordFactory} subclass for making {@link BirthRecord} objects from a line of CSV
+ * input. 
  */
 public class BirthRecordFactory extends RecordFactory<BirthRecord> {
     public BirthRecordFactory(RecordFormat format) {

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/formats/TDFormat.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/formats/TDFormat.java
@@ -4,6 +4,11 @@ import java.util.Map;
 
 import com.github.jamesross03.pop_parser.utils.RecordFormat;
 
+/**
+ * Class representing the TD format of record input, as designed by Tom Dalton
+ * (https://github.com/tomsdalton) and generated using the Valipop application
+ * (https://github.com/stacs-srg/valipop).
+ */
 public class TDFormat extends RecordFormat {
 
     @Override

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/formats/UMEAFormat.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/formats/UMEAFormat.java
@@ -4,6 +4,10 @@ import java.util.Map;
 
 import com.github.jamesross03.pop_parser.utils.RecordFormat;
 
+/**
+ * Class representing the UMEA format of record input, as used in the UMEA
+ * Swedish populations dataset.
+ */
 public class UMEAFormat extends RecordFormat {
 
     @Override

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/records/BirthRecord.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/records/BirthRecord.java
@@ -3,21 +3,43 @@ package com.github.jamesross03.pop_parser.utils.records;
 import com.github.jamesross03.pop_parser.utils.Record;
 
 /**
- * Object representing a Birth Record.
+ * Object representing a birth record.
  */
 public class BirthRecord extends Record {
+    /**
+     * Forename of data-subject
+     */
     private final String forename;
+    /**
+     * Surname of data-subject
+     */
     private final String surname;
 
+    /**
+     * Initialises a new instance of the BirthRecord class for the given attributes
+     * 
+     * @param forename forename of data-subject
+     * @param surname surname of data-subject
+     */
     public BirthRecord(String forename, String surname) {
         this.forename = forename;
         this.surname = surname;
     }
 
+    /**
+     * Gets forename of data-subject
+     * 
+     * @return forename
+     */
     public String getForename() {
         return this.forename;
     }
 
+    /**
+     * Gets surname of data-subject
+     * 
+     * @return surname
+     */
     public String getSurname() {
         return this.surname;
     }


### PR DESCRIPTION
Adds proper JavaDoc-style commenting throughout the pop-parser library and implements a github pipeline to publish JavaDocs to github pages on push to main. Closes #11 