### PR TITLE
1.2.0-alpha Release

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,0 +1,40 @@
+name: Deploy Javadoc to /docs on main
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  javadoc:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'corretto'
+        java-version: '21'
+        cache: 'maven'
+
+    - name: Generate Javadoc
+      run: mvn -B javadoc:javadoc
+
+    - name: Copy Javadoc to /docs
+      run: |
+        rm -rf docs
+        mkdir -p docs
+        cp -r target/site/apidocs/* docs/
+
+    - name: Commit and push docs
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add docs
+        git commit -m "Update Javadoc [skip ci]" || echo "No changes to commit"
+        git push
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This library exists as a proof-of-concept and currently offers **limited functio
 - Only TD record format supported
 - Only forename and surname are parsed for birth records
 
+For in-depth documentation, see the [JavaDocs](https://jamesross03.github.io/pop-parser/).
+
 ## Basic usage example
 The pop-parser library allows you to read CSV files in a pre-defined record structure into a List of Record objects. A basic example of this for birth records in TD format is seen below:
 
@@ -19,6 +21,8 @@ RecordFormat format = new TDFormat();
 RecordParser<BirthRecord> parser = new RecordParser<>(BirthRecord.class, format);
 List<BirthRecord> records = parser.parse(filepath);
 ```
+
+The parse function can also take any `Stream<String>` as a parameter, if your use-case doesn't involve a local file.
 
 ## Adding to your project
 The pop-parser library is available as a Maven package through Github Packages and can be added to your project using the following dependency:
@@ -34,7 +38,7 @@ The pop-parser library is available as a Maven package through Github Packages a
   <dependency>
     <groupId>com.github.jamesross03</groupId> 
     <artifactId>pop-parser</artifactId>
-    <version>1.0.0-alpha</version>
+    <version>1.2.0-alpha</version>
   </dependency>
 </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.jamesross03</groupId>
     <artifactId>pop-parser</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.0-alpha</version>
+    <version>1.2.0-alpha</version>
     <name>pop-parser</name>
 
     <build>

--- a/src/main/java/com/github/jamesross03/pop_parser/Constants.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/Constants.java
@@ -10,11 +10,12 @@ import com.github.jamesross03.pop_parser.utils.factories.*;
 import com.github.jamesross03.pop_parser.utils.records.*;
 
 /**
- * Defines constants used in the library
+ * Defines constants used in the pop-parser library.
  */
 public class Constants {
     /**
-     * Map of pairs of Record classes and their corresponding factories.
+     * Map of &lt;{@code Record} subclass, {@link RecordFactory} subclass
+     * instance&gt; pairs used to get corresponding factory.
      */
     public static final Map<Class<? extends Record>, Function<RecordFormat, RecordFactory<? extends Record>>> FACTORY_MAP = Map.of(
         BirthRecord.class, BirthRecordFactory::new

--- a/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
@@ -13,24 +13,28 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Parser for CSV files containing Records, where <T> is the Record class
- * (e.g BirthRecord).
+ * Parser for CSV input files containing records, where type {@code T} is a
+ * subclass of the {@code Record} abstract class representing the type of
+ * records (e.g birth).
+ * 
+ * @param <T> subclass of {@code Record} to be parsed
  */
 public class RecordParser<T extends Record> {
     /**
-     * Record Factory implementation used to create records from line in CSV.
+     * {@link RecordFactory} instance used to create {@code T}  objects from input.
      */
     private final RecordFactory<T> rf;
 
     /**
-     * Creates a new instance of the RecordParser class for <T> records.
+     * Initialises a new instance of {@code RecordParser} for parsing records of
+     * type {@code T} from input in a given format.
      * 
-     * @param type Record type <T> being parsed
-     * @param format RecordFormat corresponding to file contents
+     * @param type class of {@code Record} subclass to parse
+     * @param format format of input
      */
     @SuppressWarnings("unchecked")
     public RecordParser(Class<T> type, RecordFormat format) {
-        // Gets generic recordFactory corresponding to type <T>
+        // Gets RecordFactory instance corresponding to <T>
         var constructor = Constants.FACTORY_MAP.get(type);
 
         if (constructor == null) {
@@ -42,12 +46,12 @@ public class RecordParser<T extends Record> {
     }
 
     /**
-     * Reads all lines from an input file into <T> record objects.
+     * Parses all lines from an input file into objects of {@code Record} subclass {@code T}
      * 
-     * @param filepath 
-     * @return List of <T> record objects
-     * @throws IOException
-     * @throws CsvValidationException
+     * @param filepath filepath of input CSV
+     * @return list containing the parsed {@code T} objects
+     * @throws IOException if errors occur during file-reading
+     * @throws CsvValidationException if CSV is invalid or incorrectly formatted
      */
     public List<T> parse (String filepath) throws IOException, CsvValidationException {
         List<T> list = new ArrayList<T>();

--- a/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
@@ -6,11 +6,15 @@ import com.github.jamesross03.pop_parser.utils.Record;
 import com.opencsv.CSVReaderHeaderAware;
 import com.opencsv.exceptions.CsvValidationException;
 
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Parser for CSV input files containing records, where type {@code T} is a
@@ -54,8 +58,8 @@ public class RecordParser<T extends Record> {
      * @throws CsvValidationException if CSV is invalid or incorrectly formatted
      */
     public List<T> parse(String filepath) throws IOException, CsvValidationException {
-        try (FileReader fileReader = new FileReader(filepath)) {
-            return parse(fileReader);
+        try (Stream<String> stream = Files.lines(Path.of(filepath))) {
+            return parse(stream);
         }
     }
     

--- a/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
@@ -53,18 +53,36 @@ public class RecordParser<T extends Record> {
      * @throws IOException if errors occur during file-reading
      * @throws CsvValidationException if CSV is invalid or incorrectly formatted
      */
-    public List<T> parse (String filepath) throws IOException, CsvValidationException {
-        List<T> list = new ArrayList<T>();
-
-        try (CSVReaderHeaderAware reader = new CSVReaderHeaderAware(new FileReader(filepath))) {
+    public List<T> parse(String filepath) throws IOException, CsvValidationException {
+        try (FileReader fileReader = new FileReader(filepath)) {
+            return parse(fileReader);
+        }
+    }
+    
+    /**
+     * Parses all lines from an input stream of CSV data (with headers) into
+     * objects of {@code Record} subclass {@code T}.
+     * 
+     * @param csvStream input stream of CSV data (incl. headers)
+     * @return list containing the parsed {@code T} objects
+     * @throws IOException if errors occur during file-reading
+     * @throws CsvValidationException if CSV is invalid or incorrectly formatted
+     */
+    public List<T> parse(Stream<String> csvStream) throws IOException, CsvValidationException {
+        // Join stream of lines into one CSV string. This is inefficient Stream
+        // handling but assuming resources aren't limited.
+        String csvContent = csvStream.collect(Collectors.joining("\n"));
+        
+        try (CSVReaderHeaderAware reader = new CSVReaderHeaderAware(new StringReader(csvContent))) {
+            List<T> list = new ArrayList<>();
             Map<String, String> values;
             T r;
             while ((values = reader.readMap()) != null) {
-                if ((r =  rf.makeRecord(values)) != null) list.add(r);
+                if ((r = rf.makeRecord(values)) != null) {
+                    list.add(r);
+                }
             }
-
+            return list;
         }
-
-        return list;
     }
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/Record.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/Record.java
@@ -2,9 +2,8 @@ package com.github.jamesross03.pop_parser.utils;
 
 
 /**
- * Abstract class representing a Record type. Currently doesn't contain any 
- * variables or functions but provides type-safety for generic factory classes
- * which take a type <T>
+ * Abstract class representing a record. Doesn't define any variables or
+ * functions but provides type-safety for typed classes.
  */
 public abstract class Record {
     // See above.

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFactory.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFactory.java
@@ -3,25 +3,34 @@ package com.github.jamesross03.pop_parser.utils;
 import java.util.Map;
 
 /**
- * Abstract factory class for making record <T> objects from a line of CSV 
- * input. 
+ * Abstract factory class for making objects of Record subclass {@code T} from a
+ * line of CSV input. 
+ * 
+ * @param <T> subclass of Record abstract class
  */
 public abstract class RecordFactory<T extends Record> {
+    /**
+     * Structure of records being input.
+     */
     protected final RecordFormat format;
 
     /**
-     * Creates a new instance of a RecordFactory subclass for a given
-     * RecordFormat 
+     * Instialises a new instance of a RecordFactory subclass for use with a
+     * given RecordFormat 
      * 
-     * @param format format to use
+     * @param format record format to use
      */
     public RecordFactory(RecordFormat format) {
         this.format = format;
     }
     
     /**
-     * @param entry Map of <header, value> pairs
-     * @return generated <T>
+     * Takes a map of attribute names and their corresponding values,
+     * representing a line read in from a record file, and uses them to create a
+     * new Record object of subclass T.
+     * 
+     * @param entry Map of &lt;key, value&gt; pairs from a line of input
+     * @return generated instance of Record subclass
      */
     public abstract T makeRecord(Map<String, String> entry);
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFormat.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFormat.java
@@ -3,10 +3,23 @@ package com.github.jamesross03.pop_parser.utils;
 import java.util.Map;
 
 /**
- * Abstract class representing a RecordFormat
+ * Abstract class representing a format of record input.
  */
 public abstract class RecordFormat {
-    // Birth records
+    // ----- Birth records -----
+    /**
+     * Gets forename from a birth record
+     * 
+     * @param row Map of &lt;key, value&gt; pairs from a line of input
+     * @return forename
+     */
     public abstract String getForenameBirth(Map<String, String> row);
+
+    /**
+     * Gets surname from a birth record
+     * 
+     * @param row Map of &lt;key, value&gt; pairs from a line of input
+     * @return surname
+     */
     public abstract String getSurnameBirth(Map<String, String> row);
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/factories/BirthRecordFactory.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/factories/BirthRecordFactory.java
@@ -7,8 +7,8 @@ import com.github.jamesross03.pop_parser.utils.RecordFormat;
 import com.github.jamesross03.pop_parser.utils.records.BirthRecord;
 
 /**
- * Implementation of IRecordFactory interface for creating BirthRecords from
- * lines of CSV input.
+ * {@link RecordFactory} subclass for making {@link BirthRecord} objects from a line of CSV
+ * input. 
  */
 public class BirthRecordFactory extends RecordFactory<BirthRecord> {
     public BirthRecordFactory(RecordFormat format) {

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/formats/TDFormat.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/formats/TDFormat.java
@@ -4,6 +4,11 @@ import java.util.Map;
 
 import com.github.jamesross03.pop_parser.utils.RecordFormat;
 
+/**
+ * Class representing the TD format of record input, as designed by Tom Dalton
+ * (https://github.com/tomsdalton) and generated using the Valipop application
+ * (https://github.com/stacs-srg/valipop).
+ */
 public class TDFormat extends RecordFormat {
 
     @Override

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/formats/UMEAFormat.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/formats/UMEAFormat.java
@@ -1,0 +1,19 @@
+package com.github.jamesross03.pop_parser.utils.formats;
+
+import java.util.Map;
+
+import com.github.jamesross03.pop_parser.utils.RecordFormat;
+
+public class UMEAFormat extends RecordFormat {
+
+    @Override
+    public String getForenameBirth(Map<String, String> row) {
+        return row.get("FORENAME");
+    }
+
+    @Override
+    public String getSurnameBirth(Map<String, String> row) {
+        return row.get("SURNAME");
+    }
+    
+}

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/formats/UMEAFormat.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/formats/UMEAFormat.java
@@ -4,6 +4,10 @@ import java.util.Map;
 
 import com.github.jamesross03.pop_parser.utils.RecordFormat;
 
+/**
+ * Class representing the UMEA format of record input, as used in the UMEA
+ * Swedish populations dataset.
+ */
 public class UMEAFormat extends RecordFormat {
 
     @Override

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/records/BirthRecord.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/records/BirthRecord.java
@@ -3,21 +3,43 @@ package com.github.jamesross03.pop_parser.utils.records;
 import com.github.jamesross03.pop_parser.utils.Record;
 
 /**
- * Object representing a Birth Record.
+ * Object representing a birth record.
  */
 public class BirthRecord extends Record {
+    /**
+     * Forename of data-subject
+     */
     private final String forename;
+    /**
+     * Surname of data-subject
+     */
     private final String surname;
 
+    /**
+     * Initialises a new instance of the BirthRecord class for the given attributes
+     * 
+     * @param forename forename of data-subject
+     * @param surname surname of data-subject
+     */
     public BirthRecord(String forename, String surname) {
         this.forename = forename;
         this.surname = surname;
     }
 
+    /**
+     * Gets forename of data-subject
+     * 
+     * @return forename
+     */
     public String getForename() {
         return this.forename;
     }
 
+    /**
+     * Gets surname of data-subject
+     * 
+     * @return surname
+     */
     public String getSurname() {
         return this.surname;
     }


### PR DESCRIPTION
## Overview
Contains a number of new features/functionality to prepare the pop-parser for use in the [pop-analysis](https://github.com/jamesross03/pop-analysis) application with the Swedish UMEA populations dataset. Also improves the versatility and efficiency of the parser by allowing it to parse any Stream<String> input of CSV data line-by-line and adds a Github pages deployment of the JavaDocs for the library.

## Changelist
**Changes:**
- Parser now processes CSV data line-by-line for improved resource efficiency.

**Additions**
- Added UMEA record format, as used in the Swedish populations dataset.
- Parser can now take any Stream<String> input (filename functionality is retained for backwards-compatibility).

**Documentation**
- Adds proper JavaDoc-style commenting throughout the pop-parser library.
- Added a Github workflow to publish Javadocs to Github Pages on push to main.