### PR TITLE
1.2.2-alpha release: Final fixes for the Javadoc pipeline

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 jobs:
-  javadoc:
+  update-javadocs:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,8 +32,13 @@ jobs:
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
 
-        git fetch origin gh-pages
-        git checkout gh-pages || git checkout --orphan gh-pages
+        if git ls-remote --exit-code --heads origin gh-pages; then
+          git fetch origin gh-pages
+          git checkout gh-pages
+        else
+          git checkout --orphan gh-pages
+        fi
+
 
         rm -rf *
         cp -R target/reports/apidocs/* .

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The pop-parser library is available as a Maven package through Github Packages a
   <dependency>
     <groupId>com.github.jamesross03</groupId> 
     <artifactId>pop-parser</artifactId>
-    <version>1.2.1-alpha</version>
+    <version>1.2.2-alpha</version>
   </dependency>
 </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.jamesross03</groupId>
     <artifactId>pop-parser</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.1-alpha</version>
+    <version>1.2.2-alpha</version>
     <name>pop-parser</name>
 
     <build>


### PR DESCRIPTION
Implements final fixes for the Javadoc pipeline and prepares 1.2.2-alpha release.