### PR TITLE
1.2.3-alpha release: fixed another docs pipeline error

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -40,10 +40,10 @@ jobs:
         fi
 
 
-        rm -rf *
-        cp -R target/reports/apidocs/* .
+        rm -rf docs/*
+        cp -R target/reports/apidocs docs
 
-        git add .
+        git add docs
         git commit -m "Update Javadoc for version ${{ steps.get_version.outputs.VERSION }}" || echo "No changes to commit"
         git push
       env:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The pop-parser library is available as a Maven package through Github Packages a
   <dependency>
     <groupId>com.github.jamesross03</groupId> 
     <artifactId>pop-parser</artifactId>
-    <version>1.2.2-alpha</version>
+    <version>1.2.3-alpha</version>
   </dependency>
 </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.jamesross03</groupId>
     <artifactId>pop-parser</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.2-alpha</version>
+    <version>1.2.3-alpha</version>
     <name>pop-parser</name>
 
     <build>


### PR DESCRIPTION
Fixes another error in the Javadoc release pipeline, where new docs were being deleted at the same time as the old docs. Also prepares 1.2.3-alpha release.