### PR TITLE
1.2.4-alpha release: Javadocs pipeline now correctly creates branch

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -45,6 +45,6 @@ jobs:
 
         git add docs
         git commit -m "Update Javadoc for version ${{ steps.get_version.outputs.VERSION }}" || echo "No changes to commit"
-        git push
+        git push -u origin gh-pages
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The pop-parser library is available as a Maven package through Github Packages a
   <dependency>
     <groupId>com.github.jamesross03</groupId> 
     <artifactId>pop-parser</artifactId>
-    <version>1.2.3-alpha</version>
+    <version>1.2.4-alpha</version>
   </dependency>
 </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.jamesross03</groupId>
     <artifactId>pop-parser</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.3-alpha</version>
+    <version>1.2.4-alpha</version>
     <name>pop-parser</name>
 
     <build>


### PR DESCRIPTION
Javadocs pipeline now correctly creates the gh-pages branch. Also prepares 1.2.4-alpha release.