### PR TITLE
1.2.5-alpha release: toString overrides and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The pop-parser library is available as a Maven package through Github Packages a
   <dependency>
     <groupId>com.github.jamesross03</groupId> 
     <artifactId>pop-parser</artifactId>
-    <version>1.2.4-alpha</version>
+    <version>1.2.5-alpha</version>
   </dependency>
 </dependencies>
 ```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 A modular and reusable Java library containing functionality for parsing population record CSVs.
 
 This library exists as a proof-of-concept and currently offers **limited functionality**:
-- Only BirthRecord type supported for Record types
-- Only TD record format supported
-- Only forename and surname are parsed for birth records
+- Only limited BirthRecord support for Record types
+  - Currently only parses forename and surname 
+- Supports TD and UMEA record formats.
 
 For in-depth documentation, see the [JavaDocs](https://jamesross03.github.io/pop-parser/).
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.jamesross03</groupId>
     <artifactId>pop-parser</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.4-alpha</version>
+    <version>1.2.5-alpha</version>
     <name>pop-parser</name>
 
     <build>

--- a/src/main/java/com/github/jamesross03/pop_parser/Constants.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/Constants.java
@@ -10,11 +10,11 @@ import com.github.jamesross03.pop_parser.utils.factories.*;
 import com.github.jamesross03.pop_parser.utils.records.*;
 
 /**
- * Defines constants used in the pop-parser library.
+ * Defines constants used throughout the pop-parser library.
  */
 public class Constants {
     /**
-     * Map of &lt;{@code Record} subclass, {@link RecordFactory} subclass
+     * Map of &lt;{@link Record} subclass, {@link RecordFactory} subclass
      * instance&gt; pairs used to get corresponding factory.
      */
     public static final Map<Class<? extends Record>, Function<RecordFormat, RecordFactory<? extends Record>>> FACTORY_MAP = Map.of(

--- a/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/RecordParser.java
@@ -19,14 +19,15 @@ import java.util.stream.Stream;
 
 /**
  * Parser for CSV input files containing records, where type {@code T} is a
- * subclass of the {@code Record} abstract class representing the type of
+ * subclass of the {@link Record} abstract class representing the type of
  * records (e.g birth).
  * 
- * @param <T> subclass of {@code Record} to be parsed
+ * @param <T> subclass of {@link Record} to be parsed
  */
 public class RecordParser<T extends Record> {
     /**
-     * {@link RecordFactory} instance used to create {@code T}  objects from input.
+     * {@link RecordFactory} instance used to create {@code T}  objects from
+     * input.
      */
     private final RecordFactory<T> rf;
 
@@ -34,7 +35,7 @@ public class RecordParser<T extends Record> {
      * Initialises a new instance of {@code RecordParser} for parsing records of
      * type {@code T} from input in a given format.
      * 
-     * @param type class of {@code Record} subclass to parse
+     * @param type class of {@link Record} subclass to parse
      * @param format format of input
      */
     @SuppressWarnings("unchecked")
@@ -51,7 +52,8 @@ public class RecordParser<T extends Record> {
     }
 
     /**
-     * Parses all lines from an input file into objects of {@code Record} subclass {@code T}
+     * Parses all lines from an input file into objects of {@link Record}
+     * subclass {@code T}.
      * 
      * @param filepath filepath of input CSV
      * @return list containing the parsed {@code T} objects
@@ -66,7 +68,7 @@ public class RecordParser<T extends Record> {
     
     /**
      * Parses all lines from an input stream of CSV data (with headers) into
-     * objects of {@code Record} subclass {@code T}.
+     * objects of {@link Record} subclass {@code T}.
      * 
      * @param csvStream input stream of CSV data (incl. headers)
      * @return list containing the parsed {@code T} objects

--- a/src/main/java/com/github/jamesross03/pop_parser/package-info.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/package-info.java
@@ -1,0 +1,16 @@
+/**
+ * A modular and reusable Java library containing functionality for parsing
+ * population record CSVs.
+ * 
+ * This library exists as a proof-of-concept and currently offers limited
+ * functionality:
+ * 
+ * <ul>
+ * <li> 
+ * Only limited BirthRecord support for Record types.
+ * <ul><li> Currently only parses forename and surname. </li></ul>
+ * </li>
+ * <li> Supports TD and UMEA record formats.
+ * </ul>
+ */
+package com.github.jamesross03.pop_parser;

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/Record.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/Record.java
@@ -7,4 +7,12 @@ package com.github.jamesross03.pop_parser.utils;
  */
 public abstract class Record {
     // See above.
+
+    @Override
+    /**
+     * Gets human-readable String representation of Record
+     * 
+     * @return name of record type
+     */
+    public abstract String toString();
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFactory.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFactory.java
@@ -3,10 +3,10 @@ package com.github.jamesross03.pop_parser.utils;
 import java.util.Map;
 
 /**
- * Abstract factory class for making objects of Record subclass {@code T} from a
- * line of CSV input. 
+ * Abstract factory class for making objects of {@link Record} subclass
+ * {@code T} from a line of CSV input. 
  * 
- * @param <T> subclass of Record abstract class
+ * @param <T> subclass of {@link Record} abstract class
  */
 public abstract class RecordFactory<T extends Record> {
     /**
@@ -15,8 +15,8 @@ public abstract class RecordFactory<T extends Record> {
     protected final RecordFormat format;
 
     /**
-     * Instialises a new instance of a RecordFactory subclass for use with a
-     * given RecordFormat 
+     * Instialises a new instance of a {@code RecordFactory} subclass for use
+     * with a given {@link RecordFormat} instance.
      * 
      * @param format record format to use
      */
@@ -27,10 +27,10 @@ public abstract class RecordFactory<T extends Record> {
     /**
      * Takes a map of attribute names and their corresponding values,
      * representing a line read in from a record file, and uses them to create a
-     * new Record object of subclass T.
+     * new {@link Record} object of subclass {@code T}.
      * 
      * @param entry Map of &lt;key, value&gt; pairs from a line of input
-     * @return generated instance of Record subclass
+     * @return generated {@code T} instance
      */
     public abstract T makeRecord(Map<String, String> entry);
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFormat.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFormat.java
@@ -22,4 +22,12 @@ public abstract class RecordFormat {
      * @return surname
      */
     public abstract String getSurnameBirth(Map<String, String> row);
+
+    @Override
+    /**
+     * Gets human-readable String representation of RecordFormat
+     * 
+     * @return name of record format
+     */
+    public abstract String toString();
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFormat.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/RecordFormat.java
@@ -8,7 +8,7 @@ import java.util.Map;
 public abstract class RecordFormat {
     // ----- Birth records -----
     /**
-     * Gets forename from a birth record
+     * Gets forename from a birth record.
      * 
      * @param row Map of &lt;key, value&gt; pairs from a line of input
      * @return forename
@@ -16,7 +16,7 @@ public abstract class RecordFormat {
     public abstract String getForenameBirth(Map<String, String> row);
 
     /**
-     * Gets surname from a birth record
+     * Gets surname from a birth record.
      * 
      * @param row Map of &lt;key, value&gt; pairs from a line of input
      * @return surname

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/factories/BirthRecordFactory.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/factories/BirthRecordFactory.java
@@ -7,8 +7,8 @@ import com.github.jamesross03.pop_parser.utils.RecordFormat;
 import com.github.jamesross03.pop_parser.utils.records.BirthRecord;
 
 /**
- * {@link RecordFactory} subclass for making {@link BirthRecord} objects from a line of CSV
- * input. 
+ * {@link RecordFactory} subclass for making {@link BirthRecord} objects from a
+ * line of CSV input. 
  */
 public class BirthRecordFactory extends RecordFactory<BirthRecord> {
     public BirthRecordFactory(RecordFormat format) {

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/factories/package-info.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/factories/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Package containing implementations of the {@link RecordFactory} abstract
+ * class.
+ * 
+ * Contains factory objects used to create {@link Record} objects from a line of
+ * CSV input.
+ */
+package com.github.jamesross03.pop_parser.utils.factories;
+
+import com.github.jamesross03.pop_parser.utils.RecordFactory;

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/formats/TDFormat.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/formats/TDFormat.java
@@ -20,5 +20,10 @@ public class TDFormat extends RecordFormat {
     public String getSurnameBirth(Map<String, String> row) {
         return row.get("child's surname");
     }
+
+    @Override
+    public String toString() {
+        return "TD format";
+    }
     
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/formats/UMEAFormat.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/formats/UMEAFormat.java
@@ -19,5 +19,10 @@ public class UMEAFormat extends RecordFormat {
     public String getSurnameBirth(Map<String, String> row) {
         return row.get("SURNAME");
     }
+
+    @Override
+    public String toString() {
+        return "UMEA format";
+    }
     
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/formats/package-info.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/formats/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Package containing implementations of the {@link RecordFormat} abstract
+ * class.
+ * 
+ * Contains objects used to intepret different formats of record input from a
+ * CSV file.
+ */
+package com.github.jamesross03.pop_parser.utils.formats;
+
+import com.github.jamesross03.pop_parser.utils.RecordFormat;

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/package-info.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Package containing a number of Objects and abstract classes used by
+ * {@link RecordParser}.
+ */
+
+package com.github.jamesross03.pop_parser.utils;
+
+import com.github.jamesross03.pop_parser.RecordParser;

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/records/BirthRecord.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/records/BirthRecord.java
@@ -44,4 +44,9 @@ public class BirthRecord extends Record {
     public String getSurname() {
         return this.surname;
     }
+
+    @Override
+    public String toString() {
+        return "Birth record";
+    }
 }

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/records/BirthRecord.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/records/BirthRecord.java
@@ -7,16 +7,17 @@ import com.github.jamesross03.pop_parser.utils.Record;
  */
 public class BirthRecord extends Record {
     /**
-     * Forename of data-subject
+     * Forename of data-subject.
      */
     private final String forename;
     /**
-     * Surname of data-subject
+     * Surname of data-subject.
      */
     private final String surname;
 
     /**
-     * Initialises a new instance of the BirthRecord class for the given attributes
+     * Initialises a new instance of the {@code BirthRecord} class for the given
+     * attributes.
      * 
      * @param forename forename of data-subject
      * @param surname surname of data-subject
@@ -27,7 +28,7 @@ public class BirthRecord extends Record {
     }
 
     /**
-     * Gets forename of data-subject
+     * Gets forename of data-subject.
      * 
      * @return forename
      */
@@ -36,7 +37,7 @@ public class BirthRecord extends Record {
     }
 
     /**
-     * Gets surname of data-subject
+     * Gets surname of data-subject.
      * 
      * @return surname
      */

--- a/src/main/java/com/github/jamesross03/pop_parser/utils/records/package-info.java
+++ b/src/main/java/com/github/jamesross03/pop_parser/utils/records/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Package containing implementations of the {@link Record} abstract class.
+ * 
+ * Contains objects used to represent different types of record (such as birth,
+ * marriage, death).
+ */
+package com.github.jamesross03.pop_parser.utils.records;
+
+import com.github.jamesross03.pop_parser.utils.Record;


### PR DESCRIPTION
## Overview
Another small incremental release which adds `toString` overrides for `Record` and `RecordFormat` types for printing in
[pop-analysis](https://github.com/jamesross03/pop-analysis/) application, aswell as small documentation and README updates.

## Changelist
Additions:
- Added `toString` overrides to `Record` and `RecordFormat`

Documentation:
- Updates README to accurately list limitations
- Improves/clarifies a few JavaDoc comments
- Adds proper package-info.java files to each package to give an overview of the classes and functionality
contained within