### PR TITLE
1.2.6-alpha release: Docs pipeline fixes

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -40,7 +40,7 @@ jobs:
         fi
 
 
-        rm -rf docs/*
+        rm -rf docs
         cp -R target/reports/apidocs docs
 
         git add docs

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The pop-parser library is available as a Maven package through Github Packages a
   <dependency>
     <groupId>com.github.jamesross03</groupId> 
     <artifactId>pop-parser</artifactId>
-    <version>1.2.5-alpha</version>
+    <version>1.2.6-alpha</version>
   </dependency>
 </dependencies>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.github.jamesross03</groupId>
     <artifactId>pop-parser</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.5-alpha</version>
+    <version>1.2.6-alpha</version>
     <name>pop-parser</name>
 
     <build>


### PR DESCRIPTION
# Overview
Very small patch containing fixes to docs pipeline, where syntax of "cp" command was causing unpredictable behaviour on subsequent commits beyond the initial commit.